### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ UIAlertAction+RDActionItem.h
 To run the example project, clone the repo, and run `pod install` from the Example directory first.
 
 ## Requirements
-xCode 7
+Xcode 7
 
 ## Installation
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
